### PR TITLE
Update Ballad to 2.0.0a2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,10 @@ jobs:
       - uses: actions/setup-python@v2
 
       - name: Install Ballad
-        run: pip install -U ballad
+        run: pip install -U ballad==2.0.0a2
       
       - name: Install Dependencies
-        run: python -m ballad install -D
+        run: python -m ballad install
       
       - name: Check with Black
         run: python -m black --check .


### PR DESCRIPTION
I have just uploaded a [pre-release for Ballad](https://pypi.org/project/ballad/2.0.0a2/). It includes both the installation of Git dependencies and a basic CLI to go along with it. I recommend you watch the [2.0.0 PR](https://github.com/BD103/Ballad/pull/2) so that we can immediately update when released. For now, this alpha release should be stable enough for our uses.